### PR TITLE
fixed a bug where a browser with no navigator.geolocation was crashing

### DIFF
--- a/src/components/NoGeoLocation.js
+++ b/src/components/NoGeoLocation.js
@@ -7,11 +7,16 @@ export default () => {
   const hideNoLoc = () => setToggleNoLoc(!toggleNoLoc);
 
   useEffect(() => {
-    navigator.geolocation.watchPosition(
-      () => setToggleNoLoc(false),
-      () => setToggleNoLoc(true),
-    );
-  });
+    if (navigator.geolocation) {
+      navigator.geolocation.watchPosition(
+        () => setToggleNoLoc(false),
+        () => setToggleNoLoc(true),
+      );
+    } else {
+      setToggleNoLoc(true);
+    }
+    
+  }, []);
 
   return (
     <StyledNoGeoLocation toggleNoLoc={toggleNoLoc}>
@@ -20,7 +25,7 @@ export default () => {
           Your browser doesn't support Geolocation, or you didn't allow it.
           Centering the map to a default location
         </p>
-        <button onClick={() => hideNoLoc()}>&times;</button>
+        <button onClick={() => hideNoLoc(false)}>&times;</button>
       </div>
     </StyledNoGeoLocation>
   );


### PR DESCRIPTION
# Description

This PR fix a bug where a crash was happening if user had no navigator.geolocation.
Also it fix a bug where the error message wasn't closing clicking on the close button.

## Checklist

- [X] I have performed a self-review of my own code

