### PR TITLE
changed style to fix the closing button not to be in the right spot

### DIFF
--- a/src/components/componentStyles/AddReviewStyles.js
+++ b/src/components/componentStyles/AddReviewStyles.js
@@ -4,7 +4,7 @@ export const StyledAddReview = styled.div`
     display: ${props => props.isShown ? 'block': 'none'};
     z-index: 1;
     border-radius: 3%;
-    position: fixed;
+    position: absolute;
     text-align: center;
     width: 500px;
     height: 580px;
@@ -35,9 +35,9 @@ export const StyledAddReview = styled.div`
 
     }
     p {
-        position: fixed;
-        top: 235px;
-        right: 360px;
+        position: relative;
+        bottom: 530px;
+        left: 215px;
         color: #0000008a;
         font-size: 2rem;
     }


### PR DESCRIPTION
# Description

This PR fix styles in AddReview to show the closing button in the right spot

## Checklist

Remove any items which are not applicable.

- [X] I have performed a self-review of my own code
